### PR TITLE
Manages to employ linear timing for compiling

### DIFF
--- a/lib/zero_deploy/processor.rb
+++ b/lib/zero_deploy/processor.rb
@@ -19,7 +19,7 @@ module ZeroDeploy
 
     def assets_precompile
       action "Running: rake assets:precompile"
-      action "Asset precompilation completed (#{rand(0.01).round(2)}s)"
+      action "Asset precompilation completed (0.0000001s)"
     end
 
     def run_migrations


### PR DESCRIPTION
We've been reviewing this awesome gem and have found out a small tweak we'd make to make it even faster. This pull request deals with applying a constant time to the compiling process. Now it's faster AND reliable. 
